### PR TITLE
Add Scaffold Padding to screens

### DIFF
--- a/03-developing-ui-android-jetpack-compose/projects/final/androidApp/src/main/java/com/raywenderlich/findtime/android/ui/FindMeetingScreen.kt
+++ b/03-developing-ui-android-jetpack-compose/projects/final/androidApp/src/main/java/com/raywenderlich/findtime/android/ui/FindMeetingScreen.kt
@@ -31,7 +31,8 @@ import com.raywenderlich.findtime.TimeZoneHelperImpl
 
 @Composable
 fun FindMeetingScreen(
-    timezoneStrings: List<String>
+    timezoneStrings: List<String>,
+    padding: PaddingValues
 ) {
     val listState = rememberLazyListState()
     // 8am
@@ -44,7 +45,7 @@ fun FindMeetingScreen(
     }
     val selectedTimeZones = remember {
         val selected = SnapshotStateMap<Int, Boolean>()
-        for (i in 0..timezoneStrings.size-1) selected[i] = true
+        for (i in timezoneStrings.indices) selected[i] = true
         selected
     }
     val timezoneHelper: TimeZoneHelper = TimeZoneHelperImpl()
@@ -61,6 +62,7 @@ fun FindMeetingScreen(
     }
     Column(
         modifier = Modifier
+            .padding(padding)
             .fillMaxSize()
     ) {
         Spacer(modifier = Modifier.size(16.dp))

--- a/03-developing-ui-android-jetpack-compose/projects/final/androidApp/src/main/java/com/raywenderlich/findtime/android/ui/MainView.kt
+++ b/03-developing-ui-android-jetpack-compose/projects/final/androidApp/src/main/java/com/raywenderlich/findtime/android/ui/MainView.kt
@@ -91,7 +91,7 @@ fun MainView(actionBarFun: topBarFun = { EmptyComposable() }) {
                     }
                 }
             }
-        ) {
+        ) { padding ->
             if (showAddDialog.value) {
                 AddTimeZoneDialog(
                     onAdd = { newTimezones ->
@@ -108,8 +108,8 @@ fun MainView(actionBarFun: topBarFun = { EmptyComposable() }) {
                 )
             }
             when (selectedIndex.value) {
-                0 -> TimeZoneScreen(currentTimezoneStrings)
-                 1 -> FindMeetingScreen(currentTimezoneStrings)
+                0 -> TimeZoneScreen(currentTimezoneStrings, padding)
+                 1 -> FindMeetingScreen(currentTimezoneStrings, padding)
             }
         }
     }

--- a/03-developing-ui-android-jetpack-compose/projects/final/androidApp/src/main/java/com/raywenderlich/findtime/android/ui/TimeZoneScreen.kt
+++ b/03-developing-ui-android-jetpack-compose/projects/final/androidApp/src/main/java/com/raywenderlich/findtime/android/ui/TimeZoneScreen.kt
@@ -22,12 +22,14 @@ const val timeMillis = 1000 * 60L // 1 second
 
 @Composable
 fun TimeZoneScreen(
-    currentTimezoneStrings: SnapshotStateList<String>
+    currentTimezoneStrings: SnapshotStateList<String>,
+    padding: PaddingValues
 ) {
     val timezoneHelper: TimeZoneHelper = TimeZoneHelperImpl()
     val listState = rememberLazyListState()
     Column(
         modifier = Modifier
+            .padding(padding)
             .fillMaxSize()
     ) {
         var time by remember { mutableStateOf(timezoneHelper.currentTime()) }


### PR DESCRIPTION
add scaffold padding to account for bottom bar so that time zones are not cut off in the bottom.
<img width="424" alt="Screen Shot 2022-07-21 at 6 57 54 AM" src="https://user-images.githubusercontent.com/8250269/180198449-ae3cef9b-a0fe-4491-9ac3-c9681de1fa9c.png">
<img width="429" alt="Screen Shot 2022-07-21 at 6 48 41 AM" src="https://user-images.githubusercontent.com/8250269/180198454-a8642d1d-7e0e-41d2-9979-3fbc86378883.png">

