### PR TITLE
Remove `withContext(Dispatchers.Main)` from BookmarkViewModel

### DIFF
--- a/11-serialization/projects/challenge/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/11-serialization/projects/challenge/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/11-serialization/projects/challenge/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/11-serialization/projects/challenge/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/11-serialization/projects/final/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/11-serialization/projects/final/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/11-serialization/projects/final/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/11-serialization/projects/final/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/11-serialization/projects/starter/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/11-serialization/projects/starter/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/11-serialization/projects/starter/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/11-serialization/projects/starter/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/12-networking/projects/challenge/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/12-networking/projects/challenge/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/12-networking/projects/challenge/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/12-networking/projects/challenge/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/12-networking/projects/final/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/12-networking/projects/final/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/12-networking/projects/final/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/12-networking/projects/final/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/12-networking/projects/starter/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/12-networking/projects/starter/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/12-networking/projects/starter/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/12-networking/projects/starter/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/13-concurrency/projects/challenge/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/13-concurrency/projects/challenge/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/13-concurrency/projects/challenge/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/13-concurrency/projects/challenge/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/13-concurrency/projects/final/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/13-concurrency/projects/final/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/13-concurrency/projects/final/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/13-concurrency/projects/final/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/13-concurrency/projects/starter/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/13-concurrency/projects/starter/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/13-concurrency/projects/starter/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/13-concurrency/projects/starter/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/challenge-1/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/challenge-1/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.logger.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/challenge-1/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/challenge-1/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.logger.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/challenge-2-learn/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/challenge-2-learn/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.logger.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/challenge-2-learn/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/challenge-2-learn/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.logger.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/challenge-3/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/challenge-3/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.logger.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/challenge-3/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/challenge-3/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.logger.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/final/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/final/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/final/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/final/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/starter/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/starter/androidApp/src/main/java/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -41,9 +41,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      _items.value = bookmarks
     }
   }
 

--- a/14-creating-your-kmp-library/projects/starter/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
+++ b/14-creating-your-kmp-library/projects/starter/desktopApp/src/jvmMain/kotlin/com/kodeco/learn/ui/bookmark/BookmarkViewModel.kt
@@ -42,9 +42,7 @@ import com.kodeco.learn.ServiceLocator
 import com.kodeco.learn.data.model.KodecoEntry
 import com.kodeco.learn.domain.cb.BookmarkData
 import com.kodeco.learn.platform.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "BookmarkViewModel"
 
@@ -76,9 +74,7 @@ class BookmarkViewModel : ViewModel(), BookmarkData {
   override fun onNewBookmarksList(bookmarks: List<KodecoEntry>) {
     Logger.d(TAG, "onNewBookmarksList | newItems=${bookmarks.size}")
     viewModelScope.launch {
-      withContext(Dispatchers.Main) {
-        items.value = bookmarks
-      }
+      items.value = bookmarks
     }
   }
 


### PR DESCRIPTION
Hello @SubhrajyotiSen,

This is the change that I mentioned. There's no need to have the call to `Dispatchers.Main` since it's already running on the UI thread.